### PR TITLE
Added CircleGuardBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ IDS/IPS systems detect and prevent malicious network activities using machine le
 - [Guardrail.ai](https://shreyar.github.io/guardrails/) - A Python package to add structure, type, and quality guarantees to the outputs of large language models (LLMs).
 
 #### Detection Tools
+- [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench) - A full-fledged benchmark for evaluating protection capabilities of AI models.
 - [ProtectAI's model scanner](https://github.com/protectai/model-scanner) - A security scanner for detecting suspicious actions in serialized ML models.
 - [rebuff](https://github.com/woop/rebuff) - A prompt injection detector.
 - [langkit](https://github.com/whylabs/langkit) - A toolkit for monitoring language models and detecting attacks.


### PR DESCRIPTION
Hi!
I’d be glad if you could take a look at the following work and consider adding it to the relevant sections.

CircleGuardBench – A full-fledged benchmark for evaluating protection capabilities of AI models
• Repository: https://github.com/whitecircle-ai/circle-guard-bench
• Blog post explaining the methodology: https://huggingface.co/blog/whitecircle-ai/circleguardbench
• Hugging Face Leaderboard: https://huggingface.co/spaces/whitecircle-ai/circle-guard-bench
• Dataset: https://huggingface.co/datasets/whitecircle-ai/circleguardbench_public

I was not sure about sorting logic, so put it on the first place in the corresponding category (I assumed new-to-old sorting)